### PR TITLE
Allow to pass output file with ast via macro variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ In Xcode:
 1. In the build settings for the target that you're interested in
    dumping the AST for, set the `SWIFT_EXEC` user defined build setting
    to the path of `ast.py`.
+1. Add `AST_DUMP_FILE="$(SRCROOT)/$(TARGET_NAME).ast"` to 
+   `Preprocessor Macros`(`GCC_PREPROCESSOR_DEFINITIONS`) setting.
+   You can put any path you want. This path will be used for saving build 
+   log information with ast tree dump
 1. Build the target
-1. In the Report Navigator in Xcode, capture the AST output from the
-   build log for the target.
+1. Check output file, you set in `AST_DUMP_FILE` setting.
 
-In a shell (easier to capture output):
+In a shell:
 
 1. Build your target normally
 1. Go to the Report Navigator

--- a/ast.py
+++ b/ast.py
@@ -44,6 +44,30 @@ def build_parser():
     parser.add_argument("-parseable-output", action="store_true")
     return parser
 
+def ast_dump_file(arguments):
+    for arg in arguments:
+        if arg.startswith("-DAST_DUMP_FILE="):
+            return arg.split("=")[1]
+    return None     
+
+def dump_to_file(filename, command):
+    if filename is None:
+        return False
+
+    print("Using file %s to dump output" % filename)
+    sys.stdout.flush()
+
+    try:
+        with open(filename, "w") as outfile:
+            subprocess.call(command, stdout = outfile, stderr = outfile)  
+    except Exception as e:
+        print(e)
+        return False
+    finally:
+        sys.stdout.flush()
+
+    return True    
+
 
 def main():
     _, other_arguments = build_parser().parse_known_args()
@@ -52,7 +76,10 @@ def main():
         print(" ".join(command))
         print("\nAST:\n")
         sys.stdout.flush()
-    print(subprocess.check_output(command))
+
+    if not dump_to_file(ast_dump_file(other_arguments), command):
+        print(subprocess.check_output(command))
+
     if is_in_xcode():
         print("Exiting with 1 to stop the build")
         sys.exit(1)

--- a/ast.py
+++ b/ast.py
@@ -57,14 +57,8 @@ def dump_to_file(filename, command):
     print("Using file %s to dump output" % filename)
     sys.stdout.flush()
 
-    try:
-        with open(filename, "w") as outfile:
-            subprocess.call(command, stdout = outfile, stderr = outfile)  
-    except Exception as e:
-        print(e)
-        return False
-    finally:
-        sys.stdout.flush()
+    with open(filename, "w") as outfile:
+        subprocess.call(command, stdout = outfile, stderr = outfile)  
 
     return True    
 


### PR DESCRIPTION
By this, we can use `GCC_PREPROCESSOR_DEFINITIONS` setting to pass where dumped output file should be located. This simplifies usage of this script